### PR TITLE
Add break reminder CLI utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Celebrity Hangman Utilities
+
+This repository contains a simple celebrity-themed Hangman game along with
+supporting utilities.
+
+## Break Reminder Tool
+
+A lightweight reminder loop is available in `tools/break_reminder.py`. The
+utility sends periodic notifications encouraging you to step away from the
+keyboard.
+
+### Installation
+
+The reminder only requires the Python standard library. For desktop
+notifications, install the optional [plyer](https://github.com/kivy/plyer)
+dependency:
+
+```bash
+pip install plyer
+```
+
+Without `plyer`, the script falls back to printing reminders to the console.
+
+### Usage
+
+Run the reminder from the repository root:
+
+```bash
+python tools/break_reminder.py --interval 30
+```
+
+Key options:
+
+- `--interval`: Minutes between reminders (default: `60`).
+- `--title`: Notification title text.
+- `--message`: Notification message body.
+
+Use `Ctrl+C` to stop the reminder loop when you are done.

--- a/tools/break_reminder.py
+++ b/tools/break_reminder.py
@@ -1,0 +1,85 @@
+"""Command-line utility for scheduling periodic break reminders."""
+
+import argparse
+import importlib
+import sys
+import time
+from typing import Callable, Optional
+
+
+def get_notifier() -> Optional[Callable[[str, str], None]]:
+    """Return a callable that sends notifications or ``None`` if unavailable."""
+    spec = importlib.util.find_spec("plyer")
+    if spec is None:
+        return None
+
+    notification_module = importlib.import_module("plyer.notification")
+
+    def notifier(title: str, message: str) -> None:
+        notification_module.notify(title=title, message=message)
+
+    return notifier
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Send desktop notifications reminding you to take breaks."
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=60.0,
+        help="Minutes between reminders (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--title",
+        default="Break Reminder",
+        help="Notification title (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--message",
+        default="Time to take a break!",
+        help="Notification message (default: %(default)s)",
+    )
+    return parser.parse_args(argv)
+
+
+def send_notification(title: str, message: str, notifier: Optional[Callable[[str, str], None]]) -> None:
+    if notifier is not None:
+        notifier(title, message)
+    else:
+        print(f"{title}: {message}")
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+    notifier = get_notifier()
+
+    if notifier is None:
+        print(
+            "plyer is not installed; falling back to console output for reminders.",
+            file=sys.stderr,
+        )
+
+    if args.interval <= 0:
+        print("Interval must be greater than 0 minutes.", file=sys.stderr)
+        sys.exit(1)
+
+    delay = args.interval * 60
+
+    print(
+        "Starting break reminders every {minutes:.2f} minutes. Press Ctrl+C to stop.".format(
+            minutes=args.interval
+        )
+    )
+
+    try:
+        while True:
+            send_notification(args.title, args.message, notifier)
+            time.sleep(delay)
+    except KeyboardInterrupt:
+        print("\nBreak reminders stopped.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a CLI break reminder tool that sends notifications or console messages at a configurable interval
- document optional plyer dependency and usage instructions in the README

## Testing
- python -m compileall tools/break_reminder.py

------
https://chatgpt.com/codex/tasks/task_e_68daf5fad6288331ba898fd1d212df80